### PR TITLE
Fix gap on small screen sizes

### DIFF
--- a/components/Wishes.js
+++ b/components/Wishes.js
@@ -55,7 +55,7 @@ export default function Wishes() {
         @media (max-width: 640px) {
           .masonry-items-column:nth-child(1) {
             padding-left: 0px;
-            padding-right: 10px;
+            padding-right: 0px;
           }
           .masonry-items-column:nth-child(2) {
             padding-left: 10px;
@@ -83,7 +83,7 @@ export default function Wishes() {
 
 function Message({ github, name, note, image }) {
   return (
-    <Card as="div" sx={{ mr: 4, mb: 4 }} variant="interactive" className="card">
+    <Card as="div" sx={{ mr: [0, 4], mb: 4 }} variant="interactive" className="card">
       {(note && (
         <>
           <Box as="div" sx={{ display: 'flex', alignItems: 'center', pb: 3 }}>


### PR DESCRIPTION
Right now, there's a weird gap to the right of the cards on small screen sizes. This fixes it by using Theme UI's media query thing to only apply an existing padding rule to larger screen sizes. I tested this on a few other screen sizes and it doesn't appear to break any part of the website on any screen sizes. (There are a few instances of a similar bug on a few screen sizes, but those are unrelated to these changes.)